### PR TITLE
Create FmcToCoq.js

### DIFF
--- a/FmcToCoq.js
+++ b/FmcToCoq.js
@@ -1,0 +1,45 @@
+const fmc = require("./FormCore.js");
+
+// Coq (simplified) Abstract Syntax
+// ====
+
+// Coq variables
+const CoqVar = (name, indx) => ({ ctor: "Var", name, indx });
+// Coq references to defined objects
+const CoqRef = (name) => ({ ctor: "Ref", name });
+// Coq "Type"
+const CoqTyp = () => ({ ctor: "Typ" });
+// Coq dependent products
+const CoqAll = (name, bind, body) => ({ ctor: "All", name, bind, body });
+// Coq lambdas
+const CoqLam = (name, body) => ({ ctor: "Lam", name, body });
+// Coq applications
+const CoqApp = (func, argm) => ({ ctor: "App", func, argm });
+// Coq let-bindings
+const CoqLet = (name, expr, body) => ({ ctor: "Let", name, expr, body });
+// Coq definitions
+const CoqDef = (name, expr, body) => ({ ctor: "Def", name, expr, body });
+// Coq Theorems
+const CoqThm = (name, stmt, proof) => ({ ctor: "Thm", name, stmt, proof });
+
+/**
+ * Compiler from Core to Coq.
+ * 
+ * This compiler can't be complete for theoretical reasons:
+ * it tries to generate Coq code from Core but might
+ * fail or generate Coq code that is going to be rejected 
+ * by the Coq compiler.
+ * 
+ * @param {*} fmc_ast Core code
+ * @param {*} name name of the source
+ * @param {*} opts options
+ */
+let compile_defs = (fmc_ast, name, opts) => {
+  throw "Not implemented";
+}
+
+let compile = (fmc_code, name, opts) => {
+  compile_defs(fmc.parse_defs(fmc_code), name, opts)
+}
+
+module.exports = { compile, compile_defs };

--- a/libs.js
+++ b/libs.js
@@ -2,4 +2,5 @@ module.exports = {
   fmc: require("./FormCore.js"),
   fmc_to_js: require("./FmcToJs"),
   fmc_to_hs: require("./FmcToHs"),
+  fmc_to_coq: require("./FmcToCoq"),
 };


### PR DESCRIPTION
Hi all 👋 ,

I started to work on a Core to Coq compiler.
This is purely experimental but I thought it could be nice to be able to translate Kind's kernel down to
a well-known and trusted proof assistant! This could increase Kind's trustworthiness!

Of course, for theoretical reasons, this compiler can't be complete but I have good hopes that we will be able to compile a nice subset of Core to valid/typechecking Coq.

This PR is still a work in progress, but I opened it just to let you know that I was working on it ;)
